### PR TITLE
Ignore more in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,9 @@ dist
 _build
 _static
 _templates
+# Anything ending in env/ is a virtual env and to be ignored
+*env/
+# Emacs backup files
+*~
+# PyCharm working files
+.idea/


### PR DESCRIPTION
This adds to `.gitignore`:

* `*env/` (virtual envs)
* `*~` (Emacs backup files)
* `.idea` (PyCharm metadata)

I'm adding this to `master`, but my plan if this is approved is to make this same change on the v24 branch, at least, so that I can make use of it right away. If you'd like to see me just make this change only to v24 for now, that would also work. It just seemed like it was something that could be shared.